### PR TITLE
namespace was wrong

### DIFF
--- a/resources/config/railt.php
+++ b/resources/config/railt.php
@@ -7,7 +7,7 @@
  */
 declare(strict_types=1);
 
-use Railt\Adapters\Laravel\Controllers\GraphQLController;
+use Railt\LaravelProvider\Controllers\GraphQLController;
 
 return [
     /**


### PR DESCRIPTION
Pulled `railt/raild` then pulled `railt/laravel-provider`, then I visit `0.0.0.0/api/ui`

```
ReflectionException (-1)
Class Railt\Adapters\Laravel\Controllers\GraphQLController does not exist
```